### PR TITLE
Update account.c (login.failure: acc->login_count = 0;)

### DIFF
--- a/src/account.c
+++ b/src/account.c
@@ -872,6 +872,7 @@ void account_record_login_failure(account_t *acc) {
   }
 
   acc->login_fail_count++;
+  acc->login_count = 0;
 
   log_message(LOG_INFO,
               "[account_record_login_failure]: Failure #%u for user '%s'.\n",


### PR DESCRIPTION
No other changes were made — just add one more line in the account.c login_failure function.

I think this line of code was added yesterday, but for some reason I didn’t see it in main, so I’ve added it again just now.
This single line was added to the login_failure function in account.c to fulfill the requirement that "whenever a user fails to log in successfully, their login_count is reset to 0."