### PR TITLE
login_failure func change in account.c and add some check in login.c

### DIFF
--- a/src/account.c
+++ b/src/account.c
@@ -872,6 +872,7 @@ void account_record_login_failure(account_t *acc) {
   }
 
   acc->login_fail_count++;
+  acc->login_count = 0;
 
   log_message(LOG_INFO,
               "[account_record_login_failure]: Failure #%u for user '%s'.\n",


### PR DESCRIPTION
Add one line code in the login_failure func in account.c( I think this line of code was added yesterday but I can't find it in main, then I just add it, to fulfill the requirement "whenever a user fails to log in successfully, their login_count is reset to 0.")

For login.c:
Add a NULL check for the session pointer, Call account_record_login_failure() when password is incorrect, Call account_record_login_success() when login is successful, Check the return value of write() to detect write failures.